### PR TITLE
reconnect when error occurred

### DIFF
--- a/lib/fluent/plugin/out_redshift-out.rb
+++ b/lib/fluent/plugin/out_redshift-out.rb
@@ -314,6 +314,10 @@ class RedshiftOutput < BufferedOutput
         conn.exec(sql)
       end
     rescue PG::Error => e
+      unless @connection.nil?
+        close
+      end
+      connect_start
       raise RedshiftError.new(e)
     ensure
       conn.close if conn && @connection.nil?


### PR DESCRIPTION
Once connection error occurred, fluentd fails to connect redshift forever.
For such occasions I fix to reconnect each PG::Error.

Could you merge this PR?
